### PR TITLE
Rootless and headless image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,6 @@ RUN apk update && \
 
 COPY --from=builder /tmp/taskserver/pki /use/local/share/doc/taskd/pki/
 COPY --from=builder /usr/local/bin/taskd /usr/local/bin/
-COPY --from=builder /usr/local/bin/taskdctl /usr/local/bin/
 COPY taskd-add-user /usr/local/bin/
 COPY taskd-generate-client-key /usr/local/bin/
 COPY taskd-generate-server-key /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,17 @@
-FROM alpine:latest
+# Builder Image
+FROM alpine:latest as builder
 
-EXPOSE 53589
-
-ENV TASKDDATA=/var/lib/taskd
-
-RUN apk update
-RUN apk add git curl make cmake gcc g++ gnutls-dev util-linux-dev python3 gnutls-utils
+RUN apk update && \
+    apk add git \ 
+    curl \
+    make \
+    cmake \
+    gcc \
+    g++ \
+    gnutls-dev \
+    util-linux-dev \
+    python3 \
+    gnutls-utils
 
 WORKDIR /tmp
 RUN git clone --recursive https://github.com/GothenburgBitFactory/taskserver.git
@@ -16,15 +22,37 @@ RUN make
 RUN make test
 RUN make install
 
-RUN mv ./pki /usr/local/share/doc/taskd/
+# Final image
+FROM alpine:latest
 
-WORKDIR /
-RUN rm -rf /tmp/taskserver
+EXPOSE 53589
+ENV TASKDDATA=/home/taskd/data
 
-RUN apk del make cmake gcc g++ git
+# These are runtime dependencies for taskd
+RUN apk update && \
+    apk add gnutls-dev \
+    util-linux-dev \
+    gnutls-utils && \
+    adduser taskd --disabled-password --uid 65532
 
-COPY ./taskd-* /usr/local/bin/
+COPY --from=builder /tmp/taskserver/pki /usr/local/share/doc/taskd/pki/
+COPY --from=builder /usr/local/bin/taskd /usr/local/bin/
+COPY --from=builder /usr/local/bin/taskdctl /usr/local/bin/
+COPY taskd-add-user /usr/local/bin/
+COPY taskd-generate-client-key /usr/local/bin/
+COPY taskd-generate-server-key /usr/local/bin/
+COPY taskd-init /usr/local/bin/
+COPY entrypoint.sh /entrypoint.sh
 
-RUN chmod +x /usr/local/bin/taskd-*
+RUN chmod +x /usr/local/bin/taskd* && \
+    chmod +x /entrypoint.sh && \
+    mkdir -p /home/taskd/data && \
+    chown taskd /home/taskd/data && \
+    chown taskd /usr/local/share/doc/taskd/pki -R
 
-CMD ["taskd", "server"]
+WORKDIR /home/taskd
+
+# Drop privileges and run as a low privileged user
+USER taskd
+
+CMD ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN apk update && \
     gnutls-utils && \
     adduser taskd --disabled-password --uid 65532
 
-COPY --from=builder /tmp/taskserver/pki /usr/local/share/doc/taskd/pki/
+COPY --from=builder /tmp/taskserver/pki /use/local/share/doc/taskd/pki/
 COPY --from=builder /usr/local/bin/taskd /usr/local/bin/
 COPY --from=builder /usr/local/bin/taskdctl /usr/local/bin/
 COPY taskd-add-user /usr/local/bin/
@@ -47,8 +47,10 @@ COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /usr/local/bin/taskd* && \
     chmod +x /entrypoint.sh && \
     mkdir -p /home/taskd/data && \
+    mkdir -p /home/taskd/writeable && \
     chown taskd /home/taskd/data && \
-    chown taskd /usr/local/share/doc/taskd/pki -R
+    chown taskd /use/local/share/doc/taskd -R && \
+    chown taskd /home/taskd/writeable/ -R
 
 WORKDIR /home/taskd
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@ A simple taskd image updated monthly. Includes convenient management scripts.
 ## Setup
 
 1. Use the supplied Compose file, or copy the `taskd` service definition into another Compose file.
-2. Run `docker compose run taskd sh` to open a shell in the container.
-3. Run `taskd-init`. Info for TLS certificate generation will be prompted. **localhost cannot be used as the hostname.**
-4. Run `taskd-add-user [organization-name] [user-name]`. Filenames for the CA/client key/certificates and the new user key will be outputted.
-5. Exit the shell/container and start the taskd service via `docker compose up -d`.
-6. Copy the CA/client key/certificates out of the container volume.
+2. Set the environment variables for the taskd initialization in the docker-compose or in a file called `.env` and uncomment the corresponding line (choose any name, but modify the docker-compose accordingly). **localhost cannot be used as the hostname**.
+3. Run `docker compose up -d` to start the application.
+4. Exec inside the container with `docker exec taskd sh`.
+5. Run `taskd-add-user [organization-name] [user-name]`. Filenames for the CA/client key/certificates and the new user key will be outputted.
+6. Exit the shell/container and start the taskd service via `docker compose up -d`.
+7. Copy the CA/client key/certificates out of the container volume.
   * `docker compose cp taskd:/var/lib/taskd/ca.cert.pem .`
   * `docker compose cp taskd:/var/lib/taskd/[user-name].cert.pem .`
   * `docker compose cp taskd:/var/lib/taskd/[user-name].key.pem .`
@@ -29,6 +30,6 @@ A simple taskd image updated monthly. Includes convenient management scripts.
 
 ## Renewing/regenerating certificates
 
-By default, the certificates expire after 365 days.
+By default, the certificates expire after 365 days. Override this value with the `TASKD_CERT_EXPIRATION_DAYS` env variable.
 
 To renew/regenerate the certificates, run `taskd-generate-server-key` for CA/server keys, and run `taskd-generate-client-key [user-name]` for each client certificate.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,14 @@
 services:
   taskd:
     image: darnellandries/taskd
+    environment:
+      TASKD_HOSTNAME: changeme.example.org
+      TASKD_CERT_ORG: myorg
+      TASKD_CERT_COUNTRY: US
+      TASKD_CERT_STATE: CA
+      TASKD_CERT_LOCALITY: mycity
+      # TASKD_CERT_EXPIRATION_DAYS: 3650
+    # env_file: .env
     ports:
       - "53589:53589"
     volumes:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,7 @@ cp -r /use/local/share/doc/taskd/pki /home/taskd/writeable/
 
 # /home/taskd/data is supposedly stateful storage as in the same
 # location the main data for taskd is stored.
-if [ ! -f /home/taskd/data/config ]; then
+if [ ! -f $TASKDDATA/config ]; then
     echo "[!] Config file not found, running taskd-init."
     if [ -z "$TASKD_HOSTNAME" ] || [ -z "$TASKD_CERT_ORG" ] || [ -z "$TASKD_CERT_COUNTRY" ] || [ -z "$TASKD_CERT_STATE" ] || [ -z "$TASKD_CERT_LOCALITY" ]; then
 	echo "[-] Error: not all necessary ENV variables provided for taskd-init, aborting."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -e
+
+# /home/taskd/data is supposedly stateful storage as in the same
+# location the main data for taskd is stored.
+if [ ! -f /home/taskd/data/.taskd-init ]; then
+    echo "[!] Init file not found, running taskd-init."
+    if [ -z "$TASKD_HOSTNAME" ] || [ -z "$TASKD_CERT_ORG" ] || [ -z "$TASKD_CERT_COUNTRY" ] || [ -z "$TASKD_CERT_STATE" ] || [ -z "$TASKD_CERT_LOCALITY" ]; then
+	echo "[-] Error: not all necessary ENV variables provided for taskd-init, aborting."
+	exit 1
+    else
+	echo "[+] Running taskd-init."
+	/usr/local/bin/taskd-init
+	touch /home/taskd/data/.taskd-init
+	echo "[+] Initialization completed, starting taskd."
+    fi
+fi
+
+exec /usr/local/bin/taskd server

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# Default to 365 days of certificate validity if not set
+TASKD_CERT_EXPIRATION_DAYS="${TASKD_CERT_EXPIRATION_DAYS:-365}"
+
 # /home/taskd/data is supposedly stateful storage as in the same
 # location the main data for taskd is stored.
 if [ ! -f /home/taskd/data/.taskd-init ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,6 +5,12 @@ set -e
 # Default to 365 days of certificate validity if not set
 TASKD_CERT_EXPIRATION_DAYS="${TASKD_CERT_EXPIRATION_DAYS:-365}"
 
+# Copy the PKI folder to the homedir "writeable" folder
+# This is used so that this path can be dynamicall mounted
+# and the container can still run with a readOnly Filesystem
+
+cp -r /use/local/share/doc/taskd/pki /home/taskd/writeable/
+
 # /home/taskd/data is supposedly stateful storage as in the same
 # location the main data for taskd is stored.
 if [ ! -f /home/taskd/data/.taskd-init ]; then
@@ -19,5 +25,6 @@ if [ ! -f /home/taskd/data/.taskd-init ]; then
 	echo "[+] Initialization completed, starting taskd."
     fi
 fi
+
 
 exec /usr/local/bin/taskd server

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,15 +13,14 @@ cp -r /use/local/share/doc/taskd/pki /home/taskd/writeable/
 
 # /home/taskd/data is supposedly stateful storage as in the same
 # location the main data for taskd is stored.
-if [ ! -f /home/taskd/data/.taskd-init ]; then
-    echo "[!] Init file not found, running taskd-init."
+if [ ! -f /home/taskd/data/config ]; then
+    echo "[!] Config file not found, running taskd-init."
     if [ -z "$TASKD_HOSTNAME" ] || [ -z "$TASKD_CERT_ORG" ] || [ -z "$TASKD_CERT_COUNTRY" ] || [ -z "$TASKD_CERT_STATE" ] || [ -z "$TASKD_CERT_LOCALITY" ]; then
 	echo "[-] Error: not all necessary ENV variables provided for taskd-init, aborting."
 	exit 1
     else
 	echo "[+] Running taskd-init."
 	/usr/local/bin/taskd-init
-	touch /home/taskd/data/.taskd-init
 	echo "[+] Initialization completed, starting taskd."
     fi
 fi

--- a/taskd-generate-client-key
+++ b/taskd-generate-client-key
@@ -6,7 +6,7 @@ set -e
   exit 1;
 }
 
-cd /usr/local/share/doc/taskd/pki
+cd /home/taskd/writeable/pki
 ./generate.client $1 2> /dev/null
 
 mv ./$1.cert.pem $TASKDDATA

--- a/taskd-generate-server-key
+++ b/taskd-generate-server-key
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-cd /usr/local/share/doc/taskd/pki
+cd /home/taskd/writeable/pki
 
 rm -rf ./*.pem
 

--- a/taskd-init
+++ b/taskd-init
@@ -30,7 +30,7 @@ taskd init > /dev/null
 taskd config server 0.0.0.0:53589 > /dev/null
 taskd config log /dev/stdout > /dev/null
 
-cd /usr/local/share/doc/taskd/pki
+cd /home/taskd/writeable/pki
 
 sed -i "s/^CN=.*/CN=\"$TASKD_HOSTNAME\"/g" ./vars
 sed -i "s/^ORGANIZATION=.*/ORGANIZATION=\"$TASKD_CERT_ORG\"/g" ./vars

--- a/taskd-init
+++ b/taskd-init
@@ -37,6 +37,7 @@ sed -i "s/^ORGANIZATION=.*/ORGANIZATION=\"$TASKD_CERT_ORG\"/g" ./vars
 sed -i "s/^COUNTRY=.*/COUNTRY=\"$TASKD_CERT_COUNTRY\"/g" ./vars
 sed -i "s/^STATE=.*/STATE=\"$TASKD_CERT_STATE\"/g" ./vars
 sed -i "s/^LOCALITY=.*/LOCALITY=\"$TASKD_CERT_LOCALITY\"/g" ./vars
+sed -i "s/^EXPIRATION_DAYS=.*/EXPIRATION_DAYS=\"$TASKD_CERT_EXPIRATION_DAYS\"/g" ./vars
 
 ./generate 2> /dev/null
 


### PR DESCRIPTION
Hello,

this PR is an attempt to improve the image in some aspects:

* First, running with an unprivileged users. `taskd` does not really need to run as root, and this is generally a bad practice from security point of view. The image with the changes performed runs with a `taskd` user (UID=65532).
* Furthermore, while running "manually" with docker-compose having the image "crashing" at boot (before running `taskd-init`) is OK, if the image is run in Kubernetes, it is quite challenging to exec inside it to initialize `taskd`. For this reason, I have added a wrapper entrypoint which checks that the input variables to the `taskd-init` script are passed through ENV, and then executes automatically the `taskd-init` script if it doesn't find the configuration file that proves that the initialization already run. Once the init is performed, `exec taskd server` is executed so that PID 1 is correctly set to the `taskd` process.
* The `pki` directory can be at any location. However, being in the `/usr/share/...` path causes the container to modify the root filesystem. I have added an additional change to copy the `pki` content at runtime to `/home/taskd/writeable` path, changing the reference in the other scripts as well. With this configuration the container can be run with the full default security profile (readOnlyFilesystem, low privileges, no capabilities).
* Finally, as a side effect I optimized a bit the image build. Using multi-stage builds the size is reduced from `~140MB` to `~27MB`.
* I have updated the README to reflect these changes.

I understand that all these changes are opinionated, so I have opened the PR mostly to contribute back in case you agree with them, but I am happy to simply use the new rootless image in my home setup if you disagree. In any case, thanks for the work as it helped a lot to get `taskd` running in Kubernetes, especially the wrapper scripts!



